### PR TITLE
Add libCrypto and PHP7.1 AES GCM support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,31 @@ language: php
 
 sudo: false
 
-php:
-    - 5.4
-    - 5.5
-    - 5.6
-    - 7
-    - hhvm
-    - nightly
-
+matrix:
+    fast_finish: true
+    include:
+        - php: 5.4
+          env: deps=low
+        - php: 5.4
+          env: WITH_CRYPTO=true
+        - php: 5.5
+        - php: 5.6
+        - php: 7.0
+          env: deps=low
+        - php: 7.0
+          env: WITH_CRYPTO=true
+        - php: 7.1
+        - php: hhvm
+        - php: hhvm
+          env: deps=low
+        - php: nightly
+     
 before_script:
-    - composer install --no-interaction
+    - composer self-update
+    - sh -c 'if [ "$WITH_CRYPTO" != "" ]; then pecl install crypto-0.2.2; fi;'
     - mkdir -p build/logs
+    - if [[ $deps = low ]]; then composer update --no-interaction --prefer-lowest ; fi
+    - if [[ !$deps ]]; then composer install --no-interaction ; fi
 
 script:
     - vendor/bin/phpunit --coverage-clover build/logs/clover.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: php
 sudo: false
 
 matrix:
+    allow_failures:
+        - php: nightly
     fast_finish: true
     include:
         - php: 5.4

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The release process [is described here](doc/Release.md).
 
 This library needs at least ![PHP 5.4+](https://img.shields.io/badge/PHP-5.4%2B-ff69b4.svg).
 
-It has been successfully tested using `PHP 5.4+`, `HHVM` and `PHP 7.0+` (stable and nightly branches).
+It has been successfully tested using `PHP 5.4` to `PHP 7.1`, `HHVM` and nightly branches.
 
 If you use PHP 7.1+, this library has very good performance. **If you do not use PHP 7.1+, we highly recommend you to install the [PHP Crypto extension](https://github.com/bukka/php-crypto).**
 This extension drastically increase the performance of this library. With our pure PHP method, you will have low performance.

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ This library needs at least ![PHP 5.4+](https://img.shields.io/badge/PHP-5.4%2B-
 
 It has been successfully tested using `PHP 5.4+`, `HHVM` and `PHP 7.0+` (stable and nightly branches).
 
-If you use PHP 7.1+, this library has very good performance. **If not, we highly recommend you to install the [PHP Crypto extension](https://github.com/bukka/php-crypto).**
-This extension drastically increase the performance of this library (approx. 900x faster!).
+If you use PHP 7.1+, this library has very good performance (approx. 60k OPS). **If you do not use PHP 7.1+, we highly recommend you to install the [PHP Crypto extension](https://github.com/bukka/php-crypto).**
+This extension drastically increase the performance of this library (approx. 14k OPS). With our pure PHP method, you will have bad performance (approx. 16 OPS).
 
 # Installation
 
@@ -118,6 +118,9 @@ However, if the tag is appended at the end of the ciphertext and if it is not 12
 
 ```php
 <?php
+
+// The values $K, $IV, $C, $A hereafter have the same meaning as above
+$TL = 96; // In this example the tag length will be 96 bits
 
 $P = AESGCM::decryptWithAppendedTag($K, $IV, $C, $A, $TL);
 ```

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ This library needs at least ![PHP 5.4+](https://img.shields.io/badge/PHP-5.4%2B-
 
 It has been successfully tested using `PHP 5.4+`, `HHVM` and `PHP 7.0+` (stable and nightly branches).
 
-If you use PHP 7.1+, this library has very good performance (approx. 60k OPS). **If you do not use PHP 7.1+, we highly recommend you to install the [PHP Crypto extension](https://github.com/bukka/php-crypto).**
-This extension drastically increase the performance of this library (approx. 14k OPS). With our pure PHP method, you will have bad performance (approx. 16 OPS).
+If you use PHP 7.1+, this library has very good performance. **If you do not use PHP 7.1+, we highly recommend you to install the [PHP Crypto extension](https://github.com/bukka/php-crypto).**
+This extension drastically increase the performance of this library. With our pure PHP method, you will have low performance.
 
 # Installation
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ The release process [is described here](doc/Release.md).
 
 This library needs at least ![PHP 5.4+](https://img.shields.io/badge/PHP-5.4%2B-ff69b4.svg).
 
-It has been successfully tested using `PHP 5.4`, `PHP 5.5`, `PHP 5.6`, `HHVM` and `PHP 7` (stable and nightly branches).
+It has been successfully tested using `PHP 5.4+`, `HHVM` and `PHP 7.0+` (stable and nightly branches).
+
+If you use PHP 7.1+, this library has very good performance. **If not, we highly recommend you to install the [PHP Crypto extension](https://github.com/bukka/php-crypto).**
+This extension drastically increase the performance of this library (approx. 900x faster!).
 
 # Installation
 

--- a/composer.json
+++ b/composer.json
@@ -29,9 +29,12 @@
         "phpunit/phpunit": "^4.5|^5.0",
         "satooshi/php-coveralls": "^1.0"
     },
+   "suggest":{
+        "ext-crypto": "Highly recommended for better performance."
+   },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0.x-dev"
+            "dev-master": "1.2.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=5.4",
         "lib-openssl": "*",
-        "beberlei/assert": "^2.0",
+        "beberlei/assert": "^2.4",
         "symfony/polyfill-mbstring": "^1.1"
     },
     "require-dev": {

--- a/src/AESGCM.php
+++ b/src/AESGCM.php
@@ -16,22 +16,22 @@ use Assert\Assertion;
 final class AESGCM
 {
     /**
-     * @param string $K          Key encryption key
-     * @param string $IV         Initialization vector
-     * @param string $P          Data to encrypt (empty string for authentication)
-     * @param string $A          Additional Authentication Data
-     * @param int    $tag_length Tag length
+     * @param string      $K          Key encryption key
+     * @param string      $IV         Initialization vector
+     * @param null|string $P          Data to encrypt (null for authentication)
+     * @param null|string $A          Additional Authentication Data
+     * @param int         $tag_length Tag length
      *
      * @return array
      */
-    public static function encrypt($K, $IV, $P = '', $A = '', $tag_length = 128)
+    public static function encrypt($K, $IV, $P = null, $A = null, $tag_length = 128)
     {
         Assertion::string($K, 'The key encryption key must be a binary string.');
         $key_length = mb_strlen($K, '8bit') * 8;
         Assertion::inArray($key_length, [128, 192, 256], 'Bad key encryption key length.');
         Assertion::string($IV, 'The Initialization Vector must be a binary string.');
-        Assertion::string($P, 'The data to encrypt must be a binary string.');
-        Assertion::string($A, 'The Additional Authentication Data must be a binary string.');
+        Assertion::nullOrString($P, 'The data to encrypt must be null or a binary string.');
+        Assertion::nullOrString($A, 'The Additional Authentication Data must be null or a binary string.');
         Assertion::integer($tag_length, 'Invalid tag length. Supported values are: 128, 120, 112, 104 and 96.');
         Assertion::inArray($tag_length, [128, 120, 112, 104, 96], 'Invalid tag length. Supported values are: 128, 120, 112, 104 and 96.');
 
@@ -47,33 +47,33 @@ final class AESGCM
     /**
      * This method will append the tag at the end of the ciphertext.
      *
-     * @param string $K          Key encryption key
-     * @param string $IV         Initialization vector
-     * @param string $P          Data to encrypt (empty string for authentication)
-     * @param string $A          Additional Authentication Data
-     * @param int    $tag_length Tag length
+     * @param string      $K          Key encryption key
+     * @param string      $IV         Initialization vector
+     * @param null|string $P          Data to encrypt (null for authentication)
+     * @param null|string $A          Additional Authentication Data
+     * @param int         $tag_length Tag length
      *
      * @return string
      */
-    public static function encryptAndAppendTag($K, $IV, $P = '', $A = '', $tag_length = 128)
+    public static function encryptAndAppendTag($K, $IV, $P = null, $A = null, $tag_length = 128)
     {
         return implode(self::encrypt($K, $IV, $P, $A, $tag_length));
     }
 
     /**
-     * @param string $K          Key encryption key
-     * @param string $key_length Key length
-     * @param string $IV         Initialization vector
-     * @param string $P          Data to encrypt (empty string for authentication)
-     * @param string $A          Additional Authentication Data
-     * @param int    $tag_length Tag length
+     * @param string      $K          Key encryption key
+     * @param string      $key_length Key length
+     * @param string      $IV         Initialization vector
+     * @param null|string $P          Data to encrypt (null for authentication)
+     * @param null|string $A          Additional Authentication Data
+     * @param int         $tag_length Tag length
      *
      * @return array
      */
-    private static function encryptWithPHP71($K, $key_length, $IV, $P = '', $A = '', $tag_length = 128)
+    private static function encryptWithPHP71($K, $key_length, $IV, $P = null, $A = null, $tag_length = 128)
     {
         $mode = 'aes-'.($key_length).'-gcm';
-        $T = '';
+        $T = null;
         $C = openssl_encrypt($P, $mode, $K, OPENSSL_RAW_DATA, $IV, $T, $A, $tag_length / 8);
         Assertion::true(false !== $C, 'Unable to encrypt the data.');
 
@@ -81,16 +81,16 @@ final class AESGCM
     }
 
     /**
-     * @param string $K          Key encryption key
-     * @param string $key_length Key length
-     * @param string $IV         Initialization vector
-     * @param string $P          Data to encrypt (empty string for authentication)
-     * @param string $A          Additional Authentication Data
-     * @param int    $tag_length Tag length
+     * @param string      $K          Key encryption key
+     * @param string      $key_length Key length
+     * @param string      $IV         Initialization vector
+     * @param null|string $P          Data to encrypt (null for authentication)
+     * @param null|string $A          Additional Authentication Data
+     * @param int         $tag_length Tag length
      *
      * @return array
      */
-    private static function encryptWithPHP($K, $key_length, $IV, $P = '', $A = '', $tag_length = 128)
+    private static function encryptWithPHP($K, $key_length, $IV, $P = null, $A = null, $tag_length = 128)
     {
         list($J0, $v, $a_len_padding, $H) = self::common($K, $key_length, $IV, $A);
 
@@ -105,16 +105,16 @@ final class AESGCM
     }
 
     /**
-     * @param string $K          Key encryption key
-     * @param string $key_length Key length
-     * @param string $IV         Initialization vector
-     * @param string $P          Data to encrypt (empty string for authentication)
-     * @param string $A          Additional Authentication Data
-     * @param int    $tag_length Tag length
+     * @param string      $K          Key encryption key
+     * @param string      $key_length Key length
+     * @param string      $IV         Initialization vector
+     * @param null|string $P          Data to encrypt (null for authentication)
+     * @param null|string $A          Additional Authentication Data
+     * @param int         $tag_length Tag length
      *
      * @return array
      */
-    private static function encryptWithCryptoExtension($K, $key_length, $IV, $P = '', $A = '', $tag_length = 128)
+    private static function encryptWithCryptoExtension($K, $key_length, $IV, $P = null, $A = null, $tag_length = 128)
     {
         $cipher = \Crypto\Cipher::aes(\Crypto\Cipher::MODE_GCM, $key_length);
         $cipher->setAAD($A);
@@ -126,11 +126,11 @@ final class AESGCM
     }
 
     /**
-     * @param string $K  Key encryption key
-     * @param string $IV Initialization vector
-     * @param string $C  Data to encrypt (empty string for authentication)
-     * @param string $A  Additional Authentication Data
-     * @param string $T  Tag
+     * @param string      $K  Key encryption key
+     * @param string      $IV Initialization vector
+     * @param string|null $C  Data to encrypt (null for authentication)
+     * @param string|null $A  Additional Authentication Data
+     * @param string      $T  Tag
      *
      * @return string
      */
@@ -140,8 +140,8 @@ final class AESGCM
         $key_length = mb_strlen($K, '8bit') * 8;
         Assertion::inArray($key_length, [128, 192, 256], 'Bad key encryption key length.');
         Assertion::string($IV, 'The Initialization Vector must be a binary string.');
-        Assertion::string($C, 'The data to encrypt must be a binary string.');
-        Assertion::string($A, 'The Additional Authentication Data must be a binary string.');
+        Assertion::nullOrString($C, 'The data to encrypt must be null or a binary string.');
+        Assertion::nullOrString($A, 'The Additional Authentication Data must be null or a binary string.');
 
         $tag_length = self::getLength($T);
         Assertion::integer($tag_length, 'Invalid tag length. Supported values are: 128, 120, 112, 104 and 96.');
@@ -160,17 +160,17 @@ final class AESGCM
      * This method should be used if the tag is appended at the end of the ciphertext.
      * It is used by some AES GCM implementations such as the Java one.
      *
-     * @param string $K          Key encryption key
-     * @param string $IV         Initialization vector
-     * @param string $Ciphertext Data to encrypt (empty string for authentication)
-     * @param string $A          Additional Authentication Data
-     * @param int    $tag_length Tag length
+     * @param string      $K          Key encryption key
+     * @param string      $IV         Initialization vector
+     * @param string|null $Ciphertext Data to encrypt (null for authentication)
+     * @param string|null $A          Additional Authentication Data
+     * @param int         $tag_length Tag length
      *
      * @return string
      *
      * @see self::encryptAndAppendTag
      */
-    public static function decryptWithAppendedTag($K, $IV, $Ciphertext = '', $A = '', $tag_length = 128)
+    public static function decryptWithAppendedTag($K, $IV, $Ciphertext = null, $A = null, $tag_length = 128)
     {
         $tag_length_in_bits = $tag_length / 8;
         $C = mb_substr($Ciphertext, 0, -$tag_length_in_bits, '8bit');
@@ -180,32 +180,32 @@ final class AESGCM
     }
 
     /**
-     * @param string $K          Key encryption key
-     * @param string $key_length Key length
-     * @param string $IV         Initialization vector
-     * @param string $C          Data to encrypt (empty string for authentication)
-     * @param string $A          Additional Authentication Data
-     * @param string $T          Tag
+     * @param string      $K          Key encryption key
+     * @param string      $key_length Key length
+     * @param string      $IV         Initialization vector
+     * @param string|null $C          Data to encrypt (null for authentication)
+     * @param string|null $A          Additional Authentication Data
+     * @param string      $T          Tag
      *
      * @return string
      */
     private static function decryptWithPHP71($K, $key_length, $IV, $C, $A, $T)
     {
         $mode = 'aes-'.($key_length).'-gcm';
-        $P = openssl_decrypt($C, $mode, $K, OPENSSL_RAW_DATA, $IV, $T, $A);
+        $P = openssl_decrypt(null === $C ? '' : $C, $mode, $K, OPENSSL_RAW_DATA, $IV, $T, $A);
         Assertion::true(false !== $P, 'Unable to decrypt or to verify the tag.');
 
         return $P;
     }
 
     /**
-     * @param string $K          Key encryption key
-     * @param string $key_length Key length
-     * @param string $IV         Initialization vector
-     * @param string $C          Data to encrypt (empty string for authentication)
-     * @param string $A          Additional Authentication Data
-     * @param string $T          Tag
-     * @param int    $tag_length Tag length
+     * @param string      $K          Key encryption key
+     * @param string      $key_length Key length
+     * @param string      $IV         Initialization vector
+     * @param string|null $C          Data to encrypt (null for authentication)
+     * @param string|null $A          Additional Authentication Data
+     * @param string      $T          Tag
+     * @param int         $tag_length Tag length
      *
      * @return string
      */
@@ -226,13 +226,13 @@ final class AESGCM
     }
 
     /**
-     * @param string $K          Key encryption key
-     * @param string $key_length Key length
-     * @param string $IV         Initialization vector
-     * @param string $C          Data to encrypt (empty string for authentication)
-     * @param string $A          Additional Authentication Data
-     * @param string $T          Tag
-     * @param int    $tag_length Tag length
+     * @param string      $K          Key encryption key
+     * @param string      $key_length Key length
+     * @param string      $IV         Initialization vector
+     * @param string|null $C          Data to encrypt (null for authentication)
+     * @param string|null $A          Additional Authentication Data
+     * @param string      $T          Tag
+     * @param int         $tag_length Tag length
      *
      * @return string
      */

--- a/src/AESGCM.php
+++ b/src/AESGCM.php
@@ -74,9 +74,9 @@ final class AESGCM
     {
         $mode = 'aes-'.($key_length).'-gcm';
         $T = null;
-        $C = openssl_encrypt($P, $mode, $K, OPENSSL_RAW_DATA, $IV, $T, $A, $tag_length/8);
+        $C = openssl_encrypt($P, $mode, $K, OPENSSL_RAW_DATA, $IV, $T, $A, $tag_length / 8);
         Assertion::true(false !== $C, 'Unable to encrypt the data.');
-        
+
         return [$C, $T];
     }
 
@@ -194,7 +194,7 @@ final class AESGCM
         $mode = 'aes-'.($key_length).'-gcm';
         $P = openssl_decrypt(null === $C ? '' : $C, $mode, $K, OPENSSL_RAW_DATA, $IV, $T, $A);
         Assertion::true(false !== $P, 'Unable to decrypt or to verify the tag.');
-        
+
         return $P;
     }
 

--- a/src/AESGCM.php
+++ b/src/AESGCM.php
@@ -147,7 +147,7 @@ final class AESGCM
         Assertion::inArray($tag_length, [128, 120, 112, 104, 96], 'Invalid tag length. Supported values are: 128, 120, 112, 104 and 96.');
 
         if (version_compare(PHP_VERSION, '7.1.0RC') >= 0) {
-            return self::decryptWithPHP71($K, $key_length, $IV, $P, $A);
+            return self::decryptWithPHP71($K, $key_length, $IV, $C, $A, $T);
         } elseif (class_exists('\Crypto\Cipher')) {
             return self::decryptWithCryptoExtension($K, $key_length, $IV, $C, $A, $T, $tag_length);
         }

--- a/src/AESGCM.php
+++ b/src/AESGCM.php
@@ -34,11 +34,11 @@ final class AESGCM
         Assertion::nullOrString($A, 'The Additional Authentication Data must be null or a binary string.');
         Assertion::integer($tag_length, 'Invalid tag length. Supported values are: 128, 120, 112, 104 and 96.');
         Assertion::inArray($tag_length, [128, 120, 112, 104, 96], 'Invalid tag length. Supported values are: 128, 120, 112, 104 and 96.');
-        
+
         if (class_exists('\Crypto\Cipher')) {
             return self::encryptWithCryptoExtension($K, $key_length, $IV, $P, $A, $tag_length);
         }
-        
+
         return self::encryptWithPHP($K, $key_length, $IV, $P, $A, $tag_length);
     }
 
@@ -57,7 +57,7 @@ final class AESGCM
     {
         return implode(self::encrypt($K, $IV, $P, $A, $tag_length));
     }
-    
+
     /**
      * @param string      $K          Key encryption key
      * @param string      $key_length Key length
@@ -96,10 +96,10 @@ final class AESGCM
     {
         $cipher = \Crypto\Cipher::aes(\Crypto\Cipher::MODE_GCM, $key_length);
         $cipher->setAAD($A);
-        $cipher->setTagLength($tag_length/8);
+        $cipher->setTagLength($tag_length / 8);
         $C = $cipher->encrypt($P, $K, $IV);
         $T = $cipher->getTag();
-        
+
         return [$C, $T];
     }
 
@@ -112,7 +112,7 @@ final class AESGCM
      *
      * @return string
      */
-    public static function decrypt($K, $IV, $C = null, $A = null, $T)
+    public static function decrypt($K, $IV, $C, $A, $T)
     {
         Assertion::string($K, 'The key encryption key must be a binary string.');
         $key_length = mb_strlen($K, '8bit') * 8;
@@ -124,11 +124,11 @@ final class AESGCM
         $tag_length = self::getLength($T);
         Assertion::integer($tag_length, 'Invalid tag length. Supported values are: 128, 120, 112, 104 and 96.');
         Assertion::inArray($tag_length, [128, 120, 112, 104, 96], 'Invalid tag length. Supported values are: 128, 120, 112, 104 and 96.');
-        
+
         if (class_exists('\Crypto\Cipher')) {
             return self::decryptWithCryptoExtension($K, $key_length, $IV, $C, $A, $T, $tag_length);
         }
-        
+
         return self::decryptWithPHP($K, $key_length, $IV, $C, $A, $T, $tag_length);
     }
 
@@ -148,7 +148,7 @@ final class AESGCM
      */
     public static function decryptWithAppendedTag($K, $IV, $Ciphertext = null, $A = null, $tag_length = 128)
     {
-        $tag_length_in_bits = $tag_length/8;
+        $tag_length_in_bits = $tag_length / 8;
         $C = mb_substr($Ciphertext, 0, -$tag_length_in_bits, '8bit');
         $T = mb_substr($Ciphertext, -$tag_length_in_bits, null, '8bit');
 
@@ -166,7 +166,7 @@ final class AESGCM
      *
      * @return string
      */
-    private static function decryptWithPHP($K, $key_length, $IV, $C = null, $A = null, $T, $tag_length = 128)
+    private static function decryptWithPHP($K, $key_length, $IV, $C, $A, $T, $tag_length = 128)
     {
         list($J0, $v, $a_len_padding, $H) = self::common($K, $key_length, $IV, $A);
 
@@ -194,13 +194,13 @@ final class AESGCM
      *
      * @return string
      */
-    private static function decryptWithCryptoExtension($K, $key_length, $IV, $C = null, $A = null, $T, $tag_length = 128)
+    private static function decryptWithCryptoExtension($K, $key_length, $IV, $C, $A, $T, $tag_length = 128)
     {
         $cipher = \Crypto\Cipher::aes(\Crypto\Cipher::MODE_GCM, $key_length);
         $cipher->setTag($T);
         $cipher->setAAD($A);
-        $cipher->setTagLength($tag_length/8);
-        
+        $cipher->setTagLength($tag_length / 8);
+
         return $cipher->decrypt($C, $K, $IV);
     }
 

--- a/src/AESGCM.php
+++ b/src/AESGCM.php
@@ -35,7 +35,7 @@ final class AESGCM
         Assertion::integer($tag_length, 'Invalid tag length. Supported values are: 128, 120, 112, 104 and 96.');
         Assertion::inArray($tag_length, [128, 120, 112, 104, 96], 'Invalid tag length. Supported values are: 128, 120, 112, 104 and 96.');
 
-        if (version_compare(PHP_VERSION, '7.1.0RC5') >= 0 && null !== $P) {
+        if (version_compare(PHP_VERSION, '7.1.0RC5') >= 0) {
             return self::encryptWithPHP71($K, $key_length, $IV, $P, $A, $tag_length);
         } elseif (class_exists('\Crypto\Cipher')) {
             return self::encryptWithCryptoExtension($K, $key_length, $IV, $P, $A, $tag_length);
@@ -147,7 +147,7 @@ final class AESGCM
         Assertion::integer($tag_length, 'Invalid tag length. Supported values are: 128, 120, 112, 104 and 96.');
         Assertion::inArray($tag_length, [128, 120, 112, 104, 96], 'Invalid tag length. Supported values are: 128, 120, 112, 104 and 96.');
 
-        if (version_compare(PHP_VERSION, '7.1.0RC5') >= 0 && null !== $C) {
+        if (version_compare(PHP_VERSION, '7.1.0RC5') >= 0) {
             return self::decryptWithPHP71($K, $key_length, $IV, $C, $A, $T);
         } elseif (class_exists('\Crypto\Cipher')) {
             return self::decryptWithCryptoExtension($K, $key_length, $IV, $C, $A, $T, $tag_length);

--- a/src/AESGCM.php
+++ b/src/AESGCM.php
@@ -16,22 +16,22 @@ use Assert\Assertion;
 final class AESGCM
 {
     /**
-     * @param string      $K          Key encryption key
-     * @param string      $IV         Initialization vector
-     * @param null|string $P          Data to encrypt (null for authentication)
-     * @param null|string $A          Additional Authentication Data
-     * @param int         $tag_length Tag length
+     * @param string $K          Key encryption key
+     * @param string $IV         Initialization vector
+     * @param string $P          Data to encrypt (empty string for authentication)
+     * @param string $A          Additional Authentication Data
+     * @param int    $tag_length Tag length
      *
      * @return array
      */
-    public static function encrypt($K, $IV, $P = null, $A = null, $tag_length = 128)
+    public static function encrypt($K, $IV, $P = '', $A = '', $tag_length = 128)
     {
         Assertion::string($K, 'The key encryption key must be a binary string.');
         $key_length = mb_strlen($K, '8bit') * 8;
         Assertion::inArray($key_length, [128, 192, 256], 'Bad key encryption key length.');
         Assertion::string($IV, 'The Initialization Vector must be a binary string.');
-        Assertion::nullOrString($P, 'The data to encrypt must be null or a binary string.');
-        Assertion::nullOrString($A, 'The Additional Authentication Data must be null or a binary string.');
+        Assertion::string($P, 'The data to encrypt must be a binary string.');
+        Assertion::string($A, 'The Additional Authentication Data must be a binary string.');
         Assertion::integer($tag_length, 'Invalid tag length. Supported values are: 128, 120, 112, 104 and 96.');
         Assertion::inArray($tag_length, [128, 120, 112, 104, 96], 'Invalid tag length. Supported values are: 128, 120, 112, 104 and 96.');
 
@@ -47,33 +47,33 @@ final class AESGCM
     /**
      * This method will append the tag at the end of the ciphertext.
      *
-     * @param string      $K          Key encryption key
-     * @param string      $IV         Initialization vector
-     * @param null|string $P          Data to encrypt (null for authentication)
-     * @param null|string $A          Additional Authentication Data
-     * @param int         $tag_length Tag length
+     * @param string $K          Key encryption key
+     * @param string $IV         Initialization vector
+     * @param string $P          Data to encrypt (empty string for authentication)
+     * @param string $A          Additional Authentication Data
+     * @param int    $tag_length Tag length
      *
      * @return string
      */
-    public static function encryptAndAppendTag($K, $IV, $P = null, $A = null, $tag_length = 128)
+    public static function encryptAndAppendTag($K, $IV, $P = '', $A = '', $tag_length = 128)
     {
         return implode(self::encrypt($K, $IV, $P, $A, $tag_length));
     }
 
     /**
-     * @param string      $K          Key encryption key
-     * @param string      $key_length Key length
-     * @param string      $IV         Initialization vector
-     * @param null|string $P          Data to encrypt (null for authentication)
-     * @param null|string $A          Additional Authentication Data
-     * @param int         $tag_length Tag length
+     * @param string $K          Key encryption key
+     * @param string $key_length Key length
+     * @param string $IV         Initialization vector
+     * @param string $P          Data to encrypt (empty string for authentication)
+     * @param string $A          Additional Authentication Data
+     * @param int    $tag_length Tag length
      *
      * @return array
      */
-    private static function encryptWithPHP71($K, $key_length, $IV, $P = null, $A = null, $tag_length = 128)
+    private static function encryptWithPHP71($K, $key_length, $IV, $P = '', $A = '', $tag_length = 128)
     {
         $mode = 'aes-'.($key_length).'-gcm';
-        $T = null;
+        $T = '';
         $C = openssl_encrypt($P, $mode, $K, OPENSSL_RAW_DATA, $IV, $T, $A, $tag_length / 8);
         Assertion::true(false !== $C, 'Unable to encrypt the data.');
 
@@ -81,16 +81,16 @@ final class AESGCM
     }
 
     /**
-     * @param string      $K          Key encryption key
-     * @param string      $key_length Key length
-     * @param string      $IV         Initialization vector
-     * @param null|string $P          Data to encrypt (null for authentication)
-     * @param null|string $A          Additional Authentication Data
-     * @param int         $tag_length Tag length
+     * @param string $K          Key encryption key
+     * @param string $key_length Key length
+     * @param string $IV         Initialization vector
+     * @param string $P          Data to encrypt (empty string for authentication)
+     * @param string $A          Additional Authentication Data
+     * @param int    $tag_length Tag length
      *
      * @return array
      */
-    private static function encryptWithPHP($K, $key_length, $IV, $P = null, $A = null, $tag_length = 128)
+    private static function encryptWithPHP($K, $key_length, $IV, $P = '', $A = '', $tag_length = 128)
     {
         list($J0, $v, $a_len_padding, $H) = self::common($K, $key_length, $IV, $A);
 
@@ -105,16 +105,16 @@ final class AESGCM
     }
 
     /**
-     * @param string      $K          Key encryption key
-     * @param string      $key_length Key length
-     * @param string      $IV         Initialization vector
-     * @param null|string $P          Data to encrypt (null for authentication)
-     * @param null|string $A          Additional Authentication Data
-     * @param int         $tag_length Tag length
+     * @param string $K          Key encryption key
+     * @param string $key_length Key length
+     * @param string $IV         Initialization vector
+     * @param string $P          Data to encrypt (empty string for authentication)
+     * @param string $A          Additional Authentication Data
+     * @param int    $tag_length Tag length
      *
      * @return array
      */
-    private static function encryptWithCryptoExtension($K, $key_length, $IV, $P = null, $A = null, $tag_length = 128)
+    private static function encryptWithCryptoExtension($K, $key_length, $IV, $P = '', $A = '', $tag_length = 128)
     {
         $cipher = \Crypto\Cipher::aes(\Crypto\Cipher::MODE_GCM, $key_length);
         $cipher->setAAD($A);
@@ -126,11 +126,11 @@ final class AESGCM
     }
 
     /**
-     * @param string      $K  Key encryption key
-     * @param string      $IV Initialization vector
-     * @param string|null $C  Data to encrypt (null for authentication)
-     * @param string|null $A  Additional Authentication Data
-     * @param string      $T  Tag
+     * @param string $K  Key encryption key
+     * @param string $IV Initialization vector
+     * @param string $C  Data to encrypt (empty string for authentication)
+     * @param string $A  Additional Authentication Data
+     * @param string $T  Tag
      *
      * @return string
      */
@@ -140,8 +140,8 @@ final class AESGCM
         $key_length = mb_strlen($K, '8bit') * 8;
         Assertion::inArray($key_length, [128, 192, 256], 'Bad key encryption key length.');
         Assertion::string($IV, 'The Initialization Vector must be a binary string.');
-        Assertion::nullOrString($C, 'The data to encrypt must be null or a binary string.');
-        Assertion::nullOrString($A, 'The Additional Authentication Data must be null or a binary string.');
+        Assertion::string($C, 'The data to encrypt must be a binary string.');
+        Assertion::string($A, 'The Additional Authentication Data must be a binary string.');
 
         $tag_length = self::getLength($T);
         Assertion::integer($tag_length, 'Invalid tag length. Supported values are: 128, 120, 112, 104 and 96.');
@@ -160,17 +160,17 @@ final class AESGCM
      * This method should be used if the tag is appended at the end of the ciphertext.
      * It is used by some AES GCM implementations such as the Java one.
      *
-     * @param string      $K          Key encryption key
-     * @param string      $IV         Initialization vector
-     * @param string|null $Ciphertext Data to encrypt (null for authentication)
-     * @param string|null $A          Additional Authentication Data
-     * @param int         $tag_length Tag length
+     * @param string $K          Key encryption key
+     * @param string $IV         Initialization vector
+     * @param string $Ciphertext Data to encrypt (empty string for authentication)
+     * @param string $A          Additional Authentication Data
+     * @param int    $tag_length Tag length
      *
      * @return string
      *
      * @see self::encryptAndAppendTag
      */
-    public static function decryptWithAppendedTag($K, $IV, $Ciphertext = null, $A = null, $tag_length = 128)
+    public static function decryptWithAppendedTag($K, $IV, $Ciphertext = '', $A = '', $tag_length = 128)
     {
         $tag_length_in_bits = $tag_length / 8;
         $C = mb_substr($Ciphertext, 0, -$tag_length_in_bits, '8bit');
@@ -180,32 +180,32 @@ final class AESGCM
     }
 
     /**
-     * @param string      $K          Key encryption key
-     * @param string      $key_length Key length
-     * @param string      $IV         Initialization vector
-     * @param string|null $C          Data to encrypt (null for authentication)
-     * @param string|null $A          Additional Authentication Data
-     * @param string      $T          Tag
+     * @param string $K          Key encryption key
+     * @param string $key_length Key length
+     * @param string $IV         Initialization vector
+     * @param string $C          Data to encrypt (empty string for authentication)
+     * @param string $A          Additional Authentication Data
+     * @param string $T          Tag
      *
      * @return string
      */
     private static function decryptWithPHP71($K, $key_length, $IV, $C, $A, $T)
     {
         $mode = 'aes-'.($key_length).'-gcm';
-        $P = openssl_decrypt(null === $C ? '' : $C, $mode, $K, OPENSSL_RAW_DATA, $IV, $T, $A);
+        $P = openssl_decrypt($C, $mode, $K, OPENSSL_RAW_DATA, $IV, $T, $A);
         Assertion::true(false !== $P, 'Unable to decrypt or to verify the tag.');
 
         return $P;
     }
 
     /**
-     * @param string      $K          Key encryption key
-     * @param string      $key_length Key length
-     * @param string      $IV         Initialization vector
-     * @param string|null $C          Data to encrypt (null for authentication)
-     * @param string|null $A          Additional Authentication Data
-     * @param string      $T          Tag
-     * @param int         $tag_length Tag length
+     * @param string $K          Key encryption key
+     * @param string $key_length Key length
+     * @param string $IV         Initialization vector
+     * @param string $C          Data to encrypt (empty string for authentication)
+     * @param string $A          Additional Authentication Data
+     * @param string $T          Tag
+     * @param int    $tag_length Tag length
      *
      * @return string
      */
@@ -226,13 +226,13 @@ final class AESGCM
     }
 
     /**
-     * @param string      $K          Key encryption key
-     * @param string      $key_length Key length
-     * @param string      $IV         Initialization vector
-     * @param string|null $C          Data to encrypt (null for authentication)
-     * @param string|null $A          Additional Authentication Data
-     * @param string      $T          Tag
-     * @param int         $tag_length Tag length
+     * @param string $K          Key encryption key
+     * @param string $key_length Key length
+     * @param string $IV         Initialization vector
+     * @param string $C          Data to encrypt (empty string for authentication)
+     * @param string $A          Additional Authentication Data
+     * @param string $T          Tag
+     * @param int    $tag_length Tag length
      *
      * @return string
      */

--- a/src/AESGCM.php
+++ b/src/AESGCM.php
@@ -75,6 +75,7 @@ final class AESGCM
         $mode = 'aes-'.($key_length).'-gcm';
         $T = null;
         $C = openssl_encrypt(null === $P ? '' : $P, $mode, $K, OPENSSL_RAW_DATA, $IV, $T, $A, $tag_length/8);
+        $C = null === $P ? '' : $C;
         var_dump($P);
         var_dump(bin2hex($C));
         var_dump(bin2hex($T));

--- a/src/AESGCM.php
+++ b/src/AESGCM.php
@@ -74,10 +74,10 @@ final class AESGCM
     {
         $mode = 'aes-'.($key_length).'-gcm';
         $T = null;
-        $C = openssl_encrypt($P, $mode, $K, OPENSSL_RAW_DATA, $IV, $T, $A, $tag_length/8);
+        $C = openssl_encrypt(null === $P ? '' : $P, $mode, $K, OPENSSL_RAW_DATA, $IV, $T, $A, $tag_length/8);
+        var_dump($P);
         var_dump(bin2hex($C));
         var_dump(bin2hex($T));
-        var_dump(openssl_error_string());
 
         Assertion::true(false !== $C, 'Unable to encrypt the data.');
         
@@ -197,7 +197,7 @@ final class AESGCM
     {
         $mode = 'aes-'.($key_length).'-gcm';
         
-        return openssl_decrypt($C, $mode, $K, OPENSSL_RAW_DATA, $IV, $T, $A);
+        return openssl_decrypt(null === $C ? '' : $C, $mode, $K, OPENSSL_RAW_DATA, $IV, $T, $A);
     }
 
     /**

--- a/src/AESGCM.php
+++ b/src/AESGCM.php
@@ -195,7 +195,7 @@ final class AESGCM
         $P = openssl_decrypt(null === $C ? '' : $C, $mode, $K, OPENSSL_RAW_DATA, $IV, $T, $A);
         Assertion::true(false !== $P, 'Unable to decrypt or to verify the tag.');
         
-        return $P
+        return $P;
     }
 
     /**

--- a/src/AESGCM.php
+++ b/src/AESGCM.php
@@ -35,7 +35,7 @@ final class AESGCM
         Assertion::integer($tag_length, 'Invalid tag length. Supported values are: 128, 120, 112, 104 and 96.');
         Assertion::inArray($tag_length, [128, 120, 112, 104, 96], 'Invalid tag length. Supported values are: 128, 120, 112, 104 and 96.');
 
-        if (version_compare(PHP_VERSION, '7.1.0RC') >= 0) {
+        if (version_compare(PHP_VERSION, '7.1.0RC5') >= 0) {
             return self::encryptWithPHP71($K, $key_length, $IV, $P, $A, $tag_length);
         } elseif (class_exists('\Crypto\Cipher')) {
             return self::encryptWithCryptoExtension($K, $key_length, $IV, $P, $A, $tag_length);
@@ -75,7 +75,12 @@ final class AESGCM
         $mode = 'aes-'.($key_length).'-gcm';
         $T = null;
         $C = openssl_encrypt($P, $mode, $K, OPENSSL_RAW_DATA, $IV, $T, $A, $tag_length/8);
+        var_dump(bin2hex($C));
+        var_dump(bin2hex($T));
+        var_dump(openssl_error_string());
 
+        Assertion::true(false !== $C, 'Unable to encrypt the data.');
+        
         return [$C, $T];
     }
 

--- a/src/AESGCM.php
+++ b/src/AESGCM.php
@@ -75,7 +75,7 @@ final class AESGCM
         $mode = 'aes-'.($key_length).'-gcm';
         $T = null;
         $C = openssl_encrypt($P, $mode, $K, OPENSSL_RAW_DATA, $IV, $T, $A, $tag_length/8);
-        $C = null === $P ? '' : $C;
+        $C = null === $P ? null : $C;
         var_dump($P);
         var_dump(bin2hex($C));
         var_dump(bin2hex($T));

--- a/src/AESGCM.php
+++ b/src/AESGCM.php
@@ -168,7 +168,7 @@ final class AESGCM
      */
     private static function decryptWithPHP($K, $key_length, $IV, $C = null, $A = null, $T, $tag_length = 128)
     {
-        list($J0, $v, $a_len_padding, $H) = self::common($K, $IV, $A);
+        list($J0, $v, $a_len_padding, $H) = self::common($K, $key_length, $IV, $A);
 
         $P = self::getGCTR($K, $key_length, self::getInc(32, $J0), $C);
 

--- a/src/AESGCM.php
+++ b/src/AESGCM.php
@@ -74,7 +74,7 @@ final class AESGCM
     {
         $mode = 'aes-'.($key_length).'-gcm';
         $T = null;
-        $C = openssl_encrypt(null === $P ? '' : $P, $mode, $K, OPENSSL_RAW_DATA, $IV, $T, $A, $tag_length/8);
+        $C = openssl_encrypt($P, $mode, $K, OPENSSL_RAW_DATA, $IV, $T, $A, $tag_length/8);
         $C = null === $P ? '' : $C;
         var_dump($P);
         var_dump(bin2hex($C));

--- a/src/AESGCM.php
+++ b/src/AESGCM.php
@@ -35,7 +35,7 @@ final class AESGCM
         Assertion::integer($tag_length, 'Invalid tag length. Supported values are: 128, 120, 112, 104 and 96.');
         Assertion::inArray($tag_length, [128, 120, 112, 104, 96], 'Invalid tag length. Supported values are: 128, 120, 112, 104 and 96.');
 
-        if (version_compare(PHP_VERSION, '7.1.0') >= 0) {
+        if (version_compare(PHP_VERSION, '7.1.0RC') >= 0) {
             return self::encryptWithPHP71($K, $key_length, $IV, $P, $A, $tag_length);
         } elseif (class_exists('\Crypto\Cipher')) {
             return self::encryptWithCryptoExtension($K, $key_length, $IV, $P, $A, $tag_length);
@@ -146,7 +146,7 @@ final class AESGCM
         Assertion::integer($tag_length, 'Invalid tag length. Supported values are: 128, 120, 112, 104 and 96.');
         Assertion::inArray($tag_length, [128, 120, 112, 104, 96], 'Invalid tag length. Supported values are: 128, 120, 112, 104 and 96.');
 
-        if (version_compare(PHP_VERSION, '7.1.0') >= 0) {
+        if (version_compare(PHP_VERSION, '7.1.0RC') >= 0) {
             return self::decryptWithPHP71($K, $key_length, $IV, $P, $A);
         } elseif (class_exists('\Crypto\Cipher')) {
             return self::decryptWithCryptoExtension($K, $key_length, $IV, $C, $A, $T, $tag_length);

--- a/src/AESGCM.php
+++ b/src/AESGCM.php
@@ -35,7 +35,7 @@ final class AESGCM
         Assertion::integer($tag_length, 'Invalid tag length. Supported values are: 128, 120, 112, 104 and 96.');
         Assertion::inArray($tag_length, [128, 120, 112, 104, 96], 'Invalid tag length. Supported values are: 128, 120, 112, 104 and 96.');
 
-        if (version_compare(PHP_VERSION, '7.1.0RC5') >= 0) {
+        if (version_compare(PHP_VERSION, '7.1.0RC5') >= 0 && null !== $P) {
             return self::encryptWithPHP71($K, $key_length, $IV, $P, $A, $tag_length);
         } elseif (class_exists('\Crypto\Cipher')) {
             return self::encryptWithCryptoExtension($K, $key_length, $IV, $P, $A, $tag_length);
@@ -147,7 +147,7 @@ final class AESGCM
         Assertion::integer($tag_length, 'Invalid tag length. Supported values are: 128, 120, 112, 104 and 96.');
         Assertion::inArray($tag_length, [128, 120, 112, 104, 96], 'Invalid tag length. Supported values are: 128, 120, 112, 104 and 96.');
 
-        if (version_compare(PHP_VERSION, '7.1.0RC5') >= 0) {
+        if (version_compare(PHP_VERSION, '7.1.0RC5') >= 0 && null !== $C) {
             return self::decryptWithPHP71($K, $key_length, $IV, $C, $A, $T);
         } elseif (class_exists('\Crypto\Cipher')) {
             return self::decryptWithCryptoExtension($K, $key_length, $IV, $C, $A, $T, $tag_length);

--- a/src/AESGCM.php
+++ b/src/AESGCM.php
@@ -196,7 +196,7 @@ final class AESGCM
      */
     private static function decryptWithCryptoExtension($K, $key_length, $IV, $C = null, $A = null, $T, $tag_length = 128)
     {
-        $cipher = Cipher::aes(Cipher::MODE_GCM, $key_length);
+        $cipher = \Crypto\Cipher::aes(\Crypto\Cipher::MODE_GCM, $key_length);
         $cipher->setTag($T);
         $cipher->setAAD($A);
         $cipher->setTagLength($tag_length/8);

--- a/src/AESGCM.php
+++ b/src/AESGCM.php
@@ -72,12 +72,12 @@ final class AESGCM
     {
         list($J0, $v, $a_len_padding, $H) = self::common($K, $key_length, $IV, $A);
 
-        $C = self::getGCTR($K, self::getInc(32, $J0), $P);
+        $C = self::getGCTR($K, $key_length, self::getInc(32, $J0), $P);
         $u = self::calcVector($C);
         $c_len_padding = self::addPadding($C);
 
         $S = self::getHash($H, $A.str_pad('', $v / 8, "\0").$C.str_pad('', $u / 8, "\0").$a_len_padding.$c_len_padding);
-        $T = self::getMSB($tag_length, self::getGCTR($K, $J0, $S));
+        $T = self::getMSB($tag_length, self::getGCTR($K, $key_length, $J0, $S));
 
         return [$C, $T];
     }

--- a/tests/Benchmark.php
+++ b/tests/Benchmark.php
@@ -19,7 +19,7 @@ use Assert\Assertion;
  *
  * @param int $nb Number of encryption/decryption to perform
  */
-function runEncryptionBenchmark($nb = 100)
+function runEncryptionBenchmark($nb = 1000)
 {
     Assertion::integer($nb, 'The argument must be an integer');
     Assertion::greaterThan($nb, 1, 'The argument must be greater than 1');
@@ -33,13 +33,13 @@ function runEncryptionBenchmark($nb = 100)
     print_r('# AES-GCM ENCRYPTION BENCHMARK #'.PHP_EOL);
     print_r('################################'.PHP_EOL);
 
-    $time_start = microtime(true);
+    $time_start = -microtime(true);
     for ($i = 0; $i < $nb; $i++) {
         AESGCM::encrypt($K, $IV, $P, $A);
     }
-    $time_end = microtime(true);
-    $time = ($time_end - $time_start) / $nb * 1000;
-    printf('%f milliseconds/encryption (tested on %d encryptions)'.PHP_EOL, $time, $nb);
+    $time += microtime(true);
+    $ops = $nb/$time;
+    printf('%f OPS (tested on %d encryptions)'.PHP_EOL, $ops, $nb);
 
     print_r('################################'.PHP_EOL);
 }
@@ -49,7 +49,7 @@ function runEncryptionBenchmark($nb = 100)
  *
  * @param int $nb Number of encryption/decryption to perform
  */
-function runDecryptionBenchmark($nb = 100)
+function runDecryptionBenchmark($nb = 1000)
 {
     Assertion::integer($nb, 'The argument must be an integer');
     Assertion::greaterThan($nb, 1, 'The argument must be greater than 1');
@@ -64,13 +64,13 @@ function runDecryptionBenchmark($nb = 100)
     print_r('# AES-GCM DECRYPTION BENCHMARK #'.PHP_EOL);
     print_r('################################'.PHP_EOL);
 
-    $time_start = microtime(true);
+    $time_start = -microtime(true);
     for ($i = 0; $i < $nb; $i++) {
         AESGCM::decrypt($K, $IV, $C, $A, $T);
     }
-    $time_end = microtime(true);
-    $time = ($time_end - $time_start) / $nb * 1000;
-    printf('%f milliseconds/decryption (tested on %d decryptions)'.PHP_EOL, $time, $nb);
+    $time += microtime(true);
+    $ops = $nb/$time;
+    printf('%f OPS (tested on %d encryptions)'.PHP_EOL, $ops, $nb);
 
     print_r('################################'.PHP_EOL);
 }

--- a/tests/Benchmark.php
+++ b/tests/Benchmark.php
@@ -33,7 +33,7 @@ function runEncryptionBenchmark($nb = 1000)
     print_r('# AES-GCM ENCRYPTION BENCHMARK #'.PHP_EOL);
     print_r('################################'.PHP_EOL);
 
-    $time_start = -microtime(true);
+    $time = -microtime(true);
     for ($i = 0; $i < $nb; $i++) {
         AESGCM::encrypt($K, $IV, $P, $A);
     }
@@ -64,7 +64,7 @@ function runDecryptionBenchmark($nb = 1000)
     print_r('# AES-GCM DECRYPTION BENCHMARK #'.PHP_EOL);
     print_r('################################'.PHP_EOL);
 
-    $time_start = -microtime(true);
+    $time = -microtime(true);
     for ($i = 0; $i < $nb; $i++) {
         AESGCM::decrypt($K, $IV, $C, $A, $T);
     }

--- a/tests/Benchmark.php
+++ b/tests/Benchmark.php
@@ -38,7 +38,7 @@ function runEncryptionBenchmark($nb = 1000)
         AESGCM::encrypt($K, $IV, $P, $A);
     }
     $time += microtime(true);
-    $ops = $nb/$time;
+    $ops = $nb / $time;
     printf('%f OPS (tested on %d encryptions)'.PHP_EOL, $ops, $nb);
 
     print_r('################################'.PHP_EOL);
@@ -69,7 +69,7 @@ function runDecryptionBenchmark($nb = 1000)
         AESGCM::decrypt($K, $IV, $C, $A, $T);
     }
     $time += microtime(true);
-    $ops = $nb/$time;
+    $ops = $nb / $time;
     printf('%f OPS (tested on %d encryptions)'.PHP_EOL, $ops, $nb);
 
     print_r('################################'.PHP_EOL);

--- a/tests/IEEE802Test.php
+++ b/tests/IEEE802Test.php
@@ -24,8 +24,8 @@ class IEEE802Test extends \PHPUnit_Framework_TestCase
     {
         list($C, $T) = AESGCM::encrypt($K, $IV, $P, $A);
 
-        $this->assertEquals($C, $expected_C);
-        $this->assertEquals($T, $expected_T);
+        $this->assertEquals($expected_C, $C);
+        $this->assertEquals($expected_T, $T);
 
         $computed_P = AESGCM::decrypt($K, $IV, $C, $A, $T);
 
@@ -43,18 +43,18 @@ class IEEE802Test extends \PHPUnit_Framework_TestCase
         return [
             [
                 hex2bin('AD7A2BD03EAC835A6F620FDCB506B345'), // K
-                '', // P
+                null, // P
                 hex2bin('D609B1F056637A0D46DF998D88E5222AB2C2846512153524C0895E8108000F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E2F30313233340001'), // A
                 hex2bin('12153524C0895E81B2C28465'), // IV
-                '', // Expected C
+                null, // Expected C
                 hex2bin('F09478A9B09007D06F46E9B6A1DA25DD'), // Expected T
             ],
             [
                 hex2bin('E3C08A8F06C6E3AD95A70557B23F75483CE33021A9C72B7025666204C69C0B72'), // K
-                '', // P
+                null, // P
                 hex2bin('D609B1F056637A0D46DF998D88E5222AB2C2846512153524C0895E8108000F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E2F30313233340001'), // A
                 hex2bin('12153524C0895E81B2C28465'), // IV
-                '', // Expected C
+                null, // Expected C
                 hex2bin('2F0BC5AF409E06D609EA8B7D0FA5EA50'), // Expected T
             ],
             [
@@ -75,18 +75,18 @@ class IEEE802Test extends \PHPUnit_Framework_TestCase
             ],
             [
                 hex2bin('071B113B0CA743FECCCF3D051F737382'), // K
-                '', // P
+                null, // P
                 hex2bin('E20106D7CD0DF0761E8DCD3D88E5400076D457ED08000F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E2F303132333435363738393A0003'), // A
                 hex2bin('F0761E8DCD3D000176D457ED'), // IV
-                '', // Expected C
+                null, // Expected C
                 hex2bin('0C017BC73B227DFCC9BAFA1C41ACC353'), // Expected T
             ],
             [
                 hex2bin('691D3EE909D7F54167FD1CA0B5D769081F2BDE1AEE655FDBAB80BD5295AE6BE7'), // K
-                '', // P
+                null, // P
                 hex2bin('E20106D7CD0DF0761E8DCD3D88E5400076D457ED08000F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E2F303132333435363738393A0003'), // A
                 hex2bin('F0761E8DCD3D000176D457ED'), // IV
-                '', // Expected C
+                null, // Expected C
                 hex2bin('35217C774BBC31B63166BCF9D4ABED07'), // Expected T
             ],
             [
@@ -107,18 +107,18 @@ class IEEE802Test extends \PHPUnit_Framework_TestCase
             ],
             [
                 hex2bin('013FE00B5F11BE7F866D0CBBC55A7A90'), // K
-                '', // P
+                null, // P
                 hex2bin('84C5D513D2AAF6E5BBD2727788E523008932D6127CFDE9F9E33724C608000F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F0005'), // A
                 hex2bin('7CFDE9F9E33724C68932D612'), // IV
-                '', // Expected C
+                null, // Expected C
                 hex2bin('217867E50C2DAD74C28C3B50ABDF695A'), // Expected T
             ],
             [
                 hex2bin('83C093B58DE7FFE1C0DA926AC43FB3609AC1C80FEE1B624497EF942E2F79A823'), // K
-                '', // P
+                null, // P
                 hex2bin('84C5D513D2AAF6E5BBD2727788E523008932D6127CFDE9F9E33724C608000F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F0005'), // A
                 hex2bin('7CFDE9F9E33724C68932D612'), // IV
-                '', // Expected C
+                null, // Expected C
                 hex2bin('6EE160E8FAECA4B36C86B234920CA975'), // Expected T
             ],
             [
@@ -139,18 +139,18 @@ class IEEE802Test extends \PHPUnit_Framework_TestCase
             ],
             [
                 hex2bin('88EE087FD95DA9FBF6725AA9D757B0CD'), // K
-                '', // P
+                null, // P
                 hex2bin('68F2E77696CE7AE8E2CA4EC588E541002E58495C08000F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D0007'), // A
                 hex2bin('7AE8E2CA4EC500012E58495C'), // IV
-                '', // Expected C
+                null, // Expected C
                 hex2bin('07922B8EBCF10BB2297588CA4C614523'), // Expected T
             ],
             [
                 hex2bin('4C973DBC7364621674F8B5B89E5C15511FCED9216490FB1C1A2CAA0FFE0407E5'), // K
-                '', // P
+                null, // P
                 hex2bin('68F2E77696CE7AE8E2CA4EC588E541002E58495C08000F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D0007'), // A
                 hex2bin('7AE8E2CA4EC500012E58495C'), // IV
-                '', // Expected C
+                null, // Expected C
                 hex2bin('00BDA1B7E87608BCBF470F12157F4C07'), // Expected T
             ],
             [

--- a/tests/IEEE802Test.php
+++ b/tests/IEEE802Test.php
@@ -31,8 +31,7 @@ class IEEE802Test extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($P, $computed_P);
 
-        foreach([128, 120, 112, 104, 96] as $tag_length) {
-
+        foreach ([128, 120, 112, 104, 96] as $tag_length) {
             $c = AESGCM::encryptAndAppendTag($K, $IV, $P, $A, $tag_length);
             $p = AESGCM::decryptWithAppendedTag($K, $IV, $c, $A, $tag_length);
             $this->assertEquals($P, $p);

--- a/tests/IEEE802Test.php
+++ b/tests/IEEE802Test.php
@@ -43,18 +43,18 @@ class IEEE802Test extends \PHPUnit_Framework_TestCase
         return [
             [
                 hex2bin('AD7A2BD03EAC835A6F620FDCB506B345'), // K
-                null, // P
+                '', // P
                 hex2bin('D609B1F056637A0D46DF998D88E5222AB2C2846512153524C0895E8108000F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E2F30313233340001'), // A
                 hex2bin('12153524C0895E81B2C28465'), // IV
-                null, // Expected C
+                '', // Expected C
                 hex2bin('F09478A9B09007D06F46E9B6A1DA25DD'), // Expected T
             ],
             [
                 hex2bin('E3C08A8F06C6E3AD95A70557B23F75483CE33021A9C72B7025666204C69C0B72'), // K
-                null, // P
+                '', // P
                 hex2bin('D609B1F056637A0D46DF998D88E5222AB2C2846512153524C0895E8108000F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E2F30313233340001'), // A
                 hex2bin('12153524C0895E81B2C28465'), // IV
-                null, // Expected C
+                '', // Expected C
                 hex2bin('2F0BC5AF409E06D609EA8B7D0FA5EA50'), // Expected T
             ],
             [
@@ -75,18 +75,18 @@ class IEEE802Test extends \PHPUnit_Framework_TestCase
             ],
             [
                 hex2bin('071B113B0CA743FECCCF3D051F737382'), // K
-                null, // P
+                '', // P
                 hex2bin('E20106D7CD0DF0761E8DCD3D88E5400076D457ED08000F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E2F303132333435363738393A0003'), // A
                 hex2bin('F0761E8DCD3D000176D457ED'), // IV
-                null, // Expected C
+                '', // Expected C
                 hex2bin('0C017BC73B227DFCC9BAFA1C41ACC353'), // Expected T
             ],
             [
                 hex2bin('691D3EE909D7F54167FD1CA0B5D769081F2BDE1AEE655FDBAB80BD5295AE6BE7'), // K
-                null, // P
+                '', // P
                 hex2bin('E20106D7CD0DF0761E8DCD3D88E5400076D457ED08000F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E2F303132333435363738393A0003'), // A
                 hex2bin('F0761E8DCD3D000176D457ED'), // IV
-                null, // Expected C
+                '', // Expected C
                 hex2bin('35217C774BBC31B63166BCF9D4ABED07'), // Expected T
             ],
             [
@@ -107,18 +107,18 @@ class IEEE802Test extends \PHPUnit_Framework_TestCase
             ],
             [
                 hex2bin('013FE00B5F11BE7F866D0CBBC55A7A90'), // K
-                null, // P
+                '', // P
                 hex2bin('84C5D513D2AAF6E5BBD2727788E523008932D6127CFDE9F9E33724C608000F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F0005'), // A
                 hex2bin('7CFDE9F9E33724C68932D612'), // IV
-                null, // Expected C
+                '', // Expected C
                 hex2bin('217867E50C2DAD74C28C3B50ABDF695A'), // Expected T
             ],
             [
                 hex2bin('83C093B58DE7FFE1C0DA926AC43FB3609AC1C80FEE1B624497EF942E2F79A823'), // K
-                null, // P
+                '', // P
                 hex2bin('84C5D513D2AAF6E5BBD2727788E523008932D6127CFDE9F9E33724C608000F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F0005'), // A
                 hex2bin('7CFDE9F9E33724C68932D612'), // IV
-                null, // Expected C
+                '', // Expected C
                 hex2bin('6EE160E8FAECA4B36C86B234920CA975'), // Expected T
             ],
             [
@@ -139,18 +139,18 @@ class IEEE802Test extends \PHPUnit_Framework_TestCase
             ],
             [
                 hex2bin('88EE087FD95DA9FBF6725AA9D757B0CD'), // K
-                null, // P
+                '', // P
                 hex2bin('68F2E77696CE7AE8E2CA4EC588E541002E58495C08000F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D0007'), // A
                 hex2bin('7AE8E2CA4EC500012E58495C'), // IV
-                null, // Expected C
+                '', // Expected C
                 hex2bin('07922B8EBCF10BB2297588CA4C614523'), // Expected T
             ],
             [
                 hex2bin('4C973DBC7364621674F8B5B89E5C15511FCED9216490FB1C1A2CAA0FFE0407E5'), // K
-                null, // P
+                '', // P
                 hex2bin('68F2E77696CE7AE8E2CA4EC588E541002E58495C08000F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D0007'), // A
                 hex2bin('7AE8E2CA4EC500012E58495C'), // IV
-                null, // Expected C
+                '', // Expected C
                 hex2bin('00BDA1B7E87608BCBF470F12157F4C07'), // Expected T
             ],
             [

--- a/tests/NistTest.php
+++ b/tests/NistTest.php
@@ -31,8 +31,7 @@ class NistTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($P, $computed_P);
 
-        foreach([128, 120, 112, 104, 96] as $tag_length) {
-
+        foreach ([128, 120, 112, 104, 96] as $tag_length) {
             $c = AESGCM::encryptAndAppendTag($K, $IV, $P, $A, $tag_length);
             $p = AESGCM::decryptWithAppendedTag($K, $IV, $c, $A, $tag_length);
             $this->assertEquals($P, $p);

--- a/tests/NistTest.php
+++ b/tests/NistTest.php
@@ -24,8 +24,8 @@ class NistTest extends \PHPUnit_Framework_TestCase
     {
         list($C, $T) = AESGCM::encrypt($K, $IV, $P, $A);
 
-        $this->assertEquals($C, $expected_C);
-        $this->assertEquals($T, $expected_T);
+        $this->assertEquals($expected_C, $C);
+        $this->assertEquals($expected_T, $T);
 
         $computed_P = AESGCM::decrypt($K, $IV, $C, $A, $T);
 
@@ -43,16 +43,16 @@ class NistTest extends \PHPUnit_Framework_TestCase
         return [
             [
                 hex2bin('00000000000000000000000000000000'), // K
-                '', // P
-                '', // A
+                null, // P
+                null, // A
                 hex2bin('000000000000000000000000'), // IV
-                '', // Expected C
+                null, // Expected C
                 hex2bin('58e2fccefa7e3061367f1d57a4e7455a'), // Expected T
             ],
             [
                 hex2bin('00000000000000000000000000000000'), // K
                 hex2bin('00000000000000000000000000000000'), // P
-                '', // A
+                null, // A
                 hex2bin('000000000000000000000000'), // IV
                 hex2bin('0388dace60b6a392f328c2b971b2fe78'), // Expected C
                 hex2bin('ab6e47d42cec13bdf53a67b21257bddf'), // Expected T
@@ -60,7 +60,7 @@ class NistTest extends \PHPUnit_Framework_TestCase
             [
                 hex2bin('feffe9928665731c6d6a8f9467308308'), // K
                 hex2bin('d9313225f88406e5a55909c5aff5269a86a7a9531534f7da2e4c303d8a318a721c3c0c95956809532fcf0e2449a6b525b16aedf5aa0de657ba637b391aafd255'), // P
-                '', // A
+                null, // A
                 hex2bin('cafebabefacedbaddecaf888'), // IV
                 hex2bin('42831ec2217774244b7221b784d0d49ce3aa212f2c02a4e035c17e2329aca12e21d514b25466931c7d8f6a5aac84aa051ba30b396a0aac973d58e091473f5985'), // Expected C
                 hex2bin('4d5c2af327cd64a62cf35abd2ba6fab4'), // Expected T
@@ -91,16 +91,16 @@ class NistTest extends \PHPUnit_Framework_TestCase
             ],
             [
                 hex2bin('000000000000000000000000000000000000000000000000'), // K
-                '', // P
-                '', // A
+                null, // P
+                null, // A
                 hex2bin('000000000000000000000000'), // IV
-                '', // Expected C
+                null, // Expected C
                 hex2bin('cd33b28ac773f74ba00ed1f312572435'), // Expected T
             ],
             [
                 hex2bin('000000000000000000000000000000000000000000000000'), // K
                 hex2bin('00000000000000000000000000000000'), // P
-                '', // A
+                null, // A
                 hex2bin('000000000000000000000000'), // IV
                 hex2bin('98e7247c07f0fe411c267e4384b0f600'), // Expected C
                 hex2bin('2ff58d80033927ab8ef4d4587514f0fb'), // Expected T
@@ -108,7 +108,7 @@ class NistTest extends \PHPUnit_Framework_TestCase
             [
                 hex2bin('feffe9928665731c6d6a8f9467308308feffe9928665731c'), // K
                 hex2bin('d9313225f88406e5a55909c5aff5269a86a7a9531534f7da2e4c303d8a318a721c3c0c95956809532fcf0e2449a6b525b16aedf5aa0de657ba637b391aafd255'), // P
-                '', // A
+                null, // A
                 hex2bin('cafebabefacedbaddecaf888'), // IV
                 hex2bin('3980ca0b3c00e841eb06fac4872a2757859e1ceaa6efd984628593b40ca1e19c7d773d00c144c525ac619d18c84a3f4718e2448b2fe324d9ccda2710acade256'), // Expected C
                 hex2bin('9924a7c8587336bfb118024db8674a14'), // Expected T
@@ -139,16 +139,16 @@ class NistTest extends \PHPUnit_Framework_TestCase
             ],
             [
                 hex2bin('0000000000000000000000000000000000000000000000000000000000000000'), // K
-                '', // P
-                '', // A
+                null, // P
+                null, // A
                 hex2bin('000000000000000000000000'), // IV
-                '', // Expected C
+                null, // Expected C
                 hex2bin('530f8afbc74536b9a963b4f1c4cb738b'), // Expected T
             ],
             [
                 hex2bin('0000000000000000000000000000000000000000000000000000000000000000'), // K
                 hex2bin('00000000000000000000000000000000'), // P
-                '', // A
+                null, // A
                 hex2bin('000000000000000000000000'), // IV
                 hex2bin('cea7403d4d606b6e074ec5d3baf39d18'), // Expected C
                 hex2bin('d0d1c8a799996bf0265b98b5d48ab919'), // Expected T
@@ -156,7 +156,7 @@ class NistTest extends \PHPUnit_Framework_TestCase
             [
                 hex2bin('feffe9928665731c6d6a8f9467308308feffe9928665731c6d6a8f9467308308'), // K
                 hex2bin('d9313225f88406e5a55909c5aff5269a86a7a9531534f7da2e4c303d8a318a721c3c0c95956809532fcf0e2449a6b525b16aedf5aa0de657ba637b391aafd255'), // P
-                '', // A
+                null, // A
                 hex2bin('cafebabefacedbaddecaf888'), // IV
                 hex2bin('522dc1f099567d07f47f37a32a84427d643a8cdcbfe5c0c97598a2bd2555d1aa8cb08e48590dbb3da7b08b1056828838c5f61e6393ba7a0abcc9f662898015ad'), // Expected C
                 hex2bin('b094dac5d93471bdec1a502270e3cc6c'), // Expected T

--- a/tests/NistTest.php
+++ b/tests/NistTest.php
@@ -43,16 +43,16 @@ class NistTest extends \PHPUnit_Framework_TestCase
         return [
             [
                 hex2bin('00000000000000000000000000000000'), // K
-                null, // P
-                null, // A
+                '', // P
+                '', // A
                 hex2bin('000000000000000000000000'), // IV
-                null, // Expected C
+                '', // Expected C
                 hex2bin('58e2fccefa7e3061367f1d57a4e7455a'), // Expected T
             ],
             [
                 hex2bin('00000000000000000000000000000000'), // K
                 hex2bin('00000000000000000000000000000000'), // P
-                null, // A
+                '', // A
                 hex2bin('000000000000000000000000'), // IV
                 hex2bin('0388dace60b6a392f328c2b971b2fe78'), // Expected C
                 hex2bin('ab6e47d42cec13bdf53a67b21257bddf'), // Expected T
@@ -60,7 +60,7 @@ class NistTest extends \PHPUnit_Framework_TestCase
             [
                 hex2bin('feffe9928665731c6d6a8f9467308308'), // K
                 hex2bin('d9313225f88406e5a55909c5aff5269a86a7a9531534f7da2e4c303d8a318a721c3c0c95956809532fcf0e2449a6b525b16aedf5aa0de657ba637b391aafd255'), // P
-                null, // A
+                '', // A
                 hex2bin('cafebabefacedbaddecaf888'), // IV
                 hex2bin('42831ec2217774244b7221b784d0d49ce3aa212f2c02a4e035c17e2329aca12e21d514b25466931c7d8f6a5aac84aa051ba30b396a0aac973d58e091473f5985'), // Expected C
                 hex2bin('4d5c2af327cd64a62cf35abd2ba6fab4'), // Expected T
@@ -91,16 +91,16 @@ class NistTest extends \PHPUnit_Framework_TestCase
             ],
             [
                 hex2bin('000000000000000000000000000000000000000000000000'), // K
-                null, // P
-                null, // A
+                '', // P
+                '', // A
                 hex2bin('000000000000000000000000'), // IV
-                null, // Expected C
+                '', // Expected C
                 hex2bin('cd33b28ac773f74ba00ed1f312572435'), // Expected T
             ],
             [
                 hex2bin('000000000000000000000000000000000000000000000000'), // K
                 hex2bin('00000000000000000000000000000000'), // P
-                null, // A
+                '', // A
                 hex2bin('000000000000000000000000'), // IV
                 hex2bin('98e7247c07f0fe411c267e4384b0f600'), // Expected C
                 hex2bin('2ff58d80033927ab8ef4d4587514f0fb'), // Expected T
@@ -108,7 +108,7 @@ class NistTest extends \PHPUnit_Framework_TestCase
             [
                 hex2bin('feffe9928665731c6d6a8f9467308308feffe9928665731c'), // K
                 hex2bin('d9313225f88406e5a55909c5aff5269a86a7a9531534f7da2e4c303d8a318a721c3c0c95956809532fcf0e2449a6b525b16aedf5aa0de657ba637b391aafd255'), // P
-                null, // A
+                '', // A
                 hex2bin('cafebabefacedbaddecaf888'), // IV
                 hex2bin('3980ca0b3c00e841eb06fac4872a2757859e1ceaa6efd984628593b40ca1e19c7d773d00c144c525ac619d18c84a3f4718e2448b2fe324d9ccda2710acade256'), // Expected C
                 hex2bin('9924a7c8587336bfb118024db8674a14'), // Expected T
@@ -139,16 +139,16 @@ class NistTest extends \PHPUnit_Framework_TestCase
             ],
             [
                 hex2bin('0000000000000000000000000000000000000000000000000000000000000000'), // K
-                null, // P
-                null, // A
+                '', // P
+                '', // A
                 hex2bin('000000000000000000000000'), // IV
-                null, // Expected C
+                '', // Expected C
                 hex2bin('530f8afbc74536b9a963b4f1c4cb738b'), // Expected T
             ],
             [
                 hex2bin('0000000000000000000000000000000000000000000000000000000000000000'), // K
                 hex2bin('00000000000000000000000000000000'), // P
-                null, // A
+                '', // A
                 hex2bin('000000000000000000000000'), // IV
                 hex2bin('cea7403d4d606b6e074ec5d3baf39d18'), // Expected C
                 hex2bin('d0d1c8a799996bf0265b98b5d48ab919'), // Expected T
@@ -156,7 +156,7 @@ class NistTest extends \PHPUnit_Framework_TestCase
             [
                 hex2bin('feffe9928665731c6d6a8f9467308308feffe9928665731c6d6a8f9467308308'), // K
                 hex2bin('d9313225f88406e5a55909c5aff5269a86a7a9531534f7da2e4c303d8a318a721c3c0c95956809532fcf0e2449a6b525b16aedf5aa0de657ba637b391aafd255'), // P
-                null, // A
+                '', // A
                 hex2bin('cafebabefacedbaddecaf888'), // IV
                 hex2bin('522dc1f099567d07f47f37a32a84427d643a8cdcbfe5c0c97598a2bd2555d1aa8cb08e48590dbb3da7b08b1056828838c5f61e6393ba7a0abcc9f662898015ad'), // Expected C
                 hex2bin('b094dac5d93471bdec1a502270e3cc6c'), // Expected T


### PR DESCRIPTION
By adding the PHP7.1 and libCrypto support, the users of this library will get all the benefits of these two alternatives to the pure PHP methods without modification.
